### PR TITLE
feat: add page metadata tools

### DIFF
--- a/notes.md
+++ b/notes.md
@@ -1,7 +1,7 @@
 # TODOs
 
 - [x] Navigation control (back, forward, refresh)
-- [ ] Page metadata retrieval (title, current URL, page source)
+- [x] Page metadata retrieval (title, current URL, page source)
 - [ ] Waiting and visibility checks (wait for element visible/invisible, wait for text/attribute)
 - [ ] Element metadata (get attribute, CSS value, size/location)
 - [ ] Window/frame management (switch to frame, parent frame, window; list windows)

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -207,6 +207,64 @@ server.tool(
     }
 );
 
+// Page Metadata Tools
+server.tool(
+    "get_page_title",
+    "retrieves the current page title",
+    {},
+    async () => {
+        try {
+            const driver = getDriver();
+            const title = await driver.getTitle();
+            return {
+                content: [{ type: 'text', text: title }]
+            };
+        } catch (e) {
+            return {
+                content: [{ type: 'text', text: `Error getting page title: ${e.message}` }]
+            };
+        }
+    }
+);
+
+server.tool(
+    "get_current_url",
+    "retrieves the current page URL",
+    {},
+    async () => {
+        try {
+            const driver = getDriver();
+            const url = await driver.getCurrentUrl();
+            return {
+                content: [{ type: 'text', text: url }]
+            };
+        } catch (e) {
+            return {
+                content: [{ type: 'text', text: `Error getting current URL: ${e.message}` }]
+            };
+        }
+    }
+);
+
+server.tool(
+    "get_page_source",
+    "retrieves the current page source",
+    {},
+    async () => {
+        try {
+            const driver = getDriver();
+            const source = await driver.getPageSource();
+            return {
+                content: [{ type: 'text', text: source }]
+            };
+        } catch (e) {
+            return {
+                content: [{ type: 'text', text: `Error getting page source: ${e.message}` }]
+            };
+        }
+    }
+);
+
 // Element Interaction Tools
 server.tool(
     "find_element",


### PR DESCRIPTION
## Summary
- add tools to retrieve page title, current URL, and page source
- mark page metadata retrieval as complete in notes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7f1e9f1c832e824656a589524019