### PR TITLE
Add unit tests for server module

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "start": "node src/lib/server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "node --test"
   },
   "keywords": [],
   "author": "",

--- a/src/lib/server.js
+++ b/src/lib/server.js
@@ -1362,6 +1362,11 @@ async function cleanup() {
 process.on('SIGTERM', cleanup);
 process.on('SIGINT', cleanup);
 
-// Start the server
-const transport = new StdioServerTransport();
-await server.connect(transport);
+// Exported for testing
+export { getLocator, server, state, cleanup };
+
+// Start the server only when executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+}

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getLocator, server, state, cleanup } from '../src/lib/server.js';
+
+test('getLocator returns CSS selector', () => {
+  const locator = getLocator('css', '#main');
+  assert.strictEqual(locator.using, 'css selector');
+  assert.strictEqual(locator.value, '#main');
+});
+
+test('getLocator throws on unsupported strategy', () => {
+  assert.throws(() => getLocator('unsupported', 'value'), /Unsupported locator strategy/);
+});
+
+test('server registers start_browser tool', () => {
+  assert.ok(server._registeredTools['start_browser']);
+});
+
+test('cleanup clears state and exits', async () => {
+  let exitCode;
+  const originalExit = process.exit;
+  process.exit = (code) => { exitCode = code; };
+  state.drivers.set('sess', { quit: () => Promise.resolve() });
+  state.currentSession = 'sess';
+  await cleanup();
+  assert.strictEqual(state.drivers.size, 0);
+  assert.strictEqual(state.currentSession, null);
+  assert.strictEqual(exitCode, 0);
+  process.exit = originalExit;
+});


### PR DESCRIPTION
## Summary
- export server helpers and only start server when executed directly
- add node:test-based unit tests for server.js
- enable `npm test` using Node's built-in test runner

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb2a1bf88832e9b6729d6c853e9ca